### PR TITLE
:art: 解决 include 标签在重定向了标准输入输出后无法正确寻找模板位置的问题。

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -498,7 +498,7 @@ class Template
                     unset($array['file']);
 
                     // 分析模板文件名并读取内容
-                    $parseStr = $this->parseTemplateName($file);
+                    $parseStr = $this->parseTemplateName($file, $this->config('view_path'));
 
                     foreach ($array as $k => $v) {
                         // 以$开头字符串转换成模板变量
@@ -1116,12 +1116,13 @@ class Template
     }
 
     /**
-     * 分析加载的模板文件并读取内容 支持多个模板文件读取
+     * * 分析加载的模板文件并读取内容 支持多个模板文件读取
      * @access private
-     * @param  string $templateName 模板文件名
+     * @param string $templateName 模板文件名
+     * @param string $prefixPath   追加路径前缀
      * @return string
      */
-    private function parseTemplateName($templateName)
+    private function parseTemplateName($templateName, $prefixPath = null)
     {
         $array    = explode(',', $templateName);
         $parseStr = '';
@@ -1129,6 +1130,11 @@ class Template
         foreach ($array as $templateName) {
             if (empty($templateName)) {
                 continue;
+            }
+
+            /** 追加路径前缀 */
+            if (!empty($prefixPath)) {
+                $templateName = $prefixPath. $templateName;
             }
 
             if (0 === strpos($templateName, '$')) {


### PR DESCRIPTION
您好流年， 我是一名单独使用 think-template 模板引擎的开发者。
我目前在使用EasySwoole3 这个框架，我发现当swoole重定向标准输入输出会导致无法正确的识别include文件地址。

我简单的通过单独给include方法添加路径前缀(以config中的view_path为前缀)来支持适配。
如果您觉得不合适可以直接拒绝，感谢。