### PR TITLE
优化checkCache()方法

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -345,7 +345,13 @@ class Template
         }
 
         // 读取第一行
-        preg_match('/\/\*(.+?)\*\//', fgets($handle), $matches);
+        $line = fgets($handle);
+
+        if (false === $line) {
+            return false;
+        }
+
+        preg_match('/\/\*(.+?)\*\//', $line, $matches);
 
         if (!isset($matches[1])) {
             return false;


### PR DESCRIPTION
fgets()读取失败返回false，preg_match()方法的第二个参数只接受string类型