### PR TITLE
修改默认过滤方法使用内置的函数而非htmlentities以兼容PHP8.1

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -59,7 +59,7 @@ class Template
         'cache_id'           => '', // 模板缓存ID
         'tpl_replace_string' => [],
         'tpl_var_identify'   => 'array', // .语法变量识别，array|object|'', 为空时自动识别
-        'default_filter'     => 'htmlentities', // 默认过滤方法 用于普通标签输出
+        'default_filter'     => 'tp_htmlentities', // 默认过滤方法 用于普通标签输出
     ];
 
     /**

--- a/src/facade/Template.php
+++ b/src/facade/Template.php
@@ -13,7 +13,8 @@ namespace think\facade;
 
 if (class_exists('think\Facade')) {
     class Facade extends \think\Facade
-    {}
+    {
+    }
 } else {
     class Facade
     {
@@ -31,7 +32,8 @@ if (class_exists('think\Facade')) {
          * @return string
          */
         protected static function getFacadeClass()
-        {}
+        {
+        }
 
         /**
          * 创建Facade实例
@@ -52,7 +54,6 @@ if (class_exists('think\Facade')) {
             }
 
             return self::$instance;
-
         }
 
         // 调用实际类的方法
@@ -79,5 +80,16 @@ class Template extends Facade
     protected static function getFacadeClass()
     {
         return 'think\Template';
+    }
+}
+
+if (!function_exists('tp_htmlentities')) {
+    function tp_htmlentities($string)
+    {
+        if (is_null($string)) {
+            $string = '';
+        }
+
+        return htmlentities($string);
     }
 }


### PR DESCRIPTION
默认的过滤方法为`htmlentities`,然而在PHP8.1中,这个函数的表现发生了变化,第一个参数只接受string,
需要在类库中内置一个自定义的函数,然后调用`htmlentities`.
```
if (!function_exists('tp_htmlentities')) {
    function tp_htmlentities($string)
    {
        if (is_null($string)) {
            $string = '';
        }

        return htmlentities($string);
    }
}

```