### PR TITLE
基于 PHP 8 的代码改进

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-	   "php": ">=7.1.0",
-       "psr/simple-cache": "^1.0"
+       "php": ">=8.0.0",
+       "psr/simple-cache": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<phpunit
+        bootstrap="tests/bootstrap.php"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+>
+    <testsuites>
+        <testsuite name="unit">
+            <directory phpVersion="8.0.0" phpVersionOperator=">=">tests/think</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Template.php
+++ b/src/Template.php
@@ -975,7 +975,7 @@ class Template
     {
         $varStr = trim($varStr);
 
-        if (preg_match_all('/\$[a-zA-Z_](?>\w*)(?:[:\.][0-9a-zA-Z_](?>\w*))+/', $varStr, $matches, PREG_OFFSET_CAPTURE)) {
+        if (preg_match_all('/\$[a-zA-Z_](?>\w*)(?:[:.][0-9a-zA-Z_](?>\w*))+/', $varStr, $matches, PREG_OFFSET_CAPTURE)) {
             static $_varParseList = [];
 
             while ($matches[0]) {

--- a/src/Template.php
+++ b/src/Template.php
@@ -14,6 +14,7 @@ namespace think;
 
 use Exception;
 use Psr\SimpleCache\CacheInterface;
+use think\template\contract\DriverInterface;
 
 /**
  * ThinkPHP分离出来的模板引擎
@@ -26,13 +27,13 @@ class Template
      * 模板变量
      * @var array
      */
-    protected $data = [];
+    protected array $data = [];
 
     /**
      * 模板配置参数
      * @var array
      */
-    protected $config = [
+    protected array $config = [
         'view_path'          => '', // 模板路径
         'view_suffix'        => 'html', // 默认模板文件后缀
         'view_depr'          => DIRECTORY_SEPARATOR,
@@ -66,31 +67,31 @@ class Template
      * 保留内容信息
      * @var array
      */
-    private $literal = [];
+    private array $literal = [];
 
     /**
      * 扩展解析规则
      * @var array
      */
-    private $extend = [];
+    private array $extend = [];
 
     /**
      * 模板包含信息
      * @var array
      */
-    private $includeFile = [];
+    private array $includeFile = [];
 
     /**
      * 模板存储对象
-     * @var object
+     * @var DriverInterface
      */
-    protected $storage;
+    protected DriverInterface $storage;
 
     /**
      * 查询缓存对象
      * @var CacheInterface
      */
-    protected $cache;
+    protected CacheInterface $cache;
 
     /**
      * 架构函数
@@ -122,7 +123,7 @@ class Template
      * @param  array $vars 模板变量
      * @return $this
      */
-    public function assign(array $vars = [])
+    public function assign(array $vars = []): static
     {
         $this->data = array_merge($this->data, $vars);
         return $this;
@@ -131,10 +132,10 @@ class Template
     /**
      * 模板引擎参数赋值
      * @access public
-     * @param  string $name
-     * @param  mixed  $value
+     * @param string $name
+     * @param  mixed $value
      */
-    public function __set($name, $value)
+    public function __set(string $name, $value)
     {
         $this->config[$name] = $value;
     }
@@ -156,7 +157,7 @@ class Template
      * @param  array $config
      * @return $this
      */
-    public function config(array $config)
+    public function config(array $config): static
     {
         $this->config = array_merge($this->config, $config);
         return $this;
@@ -202,8 +203,8 @@ class Template
     /**
      * 扩展模板解析规则
      * @access public
-     * @param  string   $rule 解析规则
-     * @param  callable $callback 解析规则
+     * @param string        $rule     解析规则
+     * @param callable|null $callback 解析规则回调
      * @return void
      */
     public function extend(string $rule, callable $callback = null): void
@@ -305,11 +306,11 @@ class Template
     /**
      * 设置布局
      * @access public
-     * @param  mixed  $name 布局模板名称 false 则关闭布局
-     * @param  string $replace 布局模板内容替换标识
+     * @param bool|string $name    布局模板名称 false 则关闭布局
+     * @param string      $replace 布局模板内容替换标识
      * @return $this
      */
-    public function layout($name, string $replace = '')
+    public function layout(bool|string $name, string $replace = ''): static
     {
         if (false === $name) {
             // 关闭布局
@@ -332,8 +333,7 @@ class Template
     }
 
     /**
-     * 检查编译缓存是否有效
-     * 如果无效则需要重新编译
+     * 检查编译缓存是否有效，如果无效则需要重新编译
      * @access private
      * @param  string $cacheFile 缓存文件名
      * @return bool
@@ -762,13 +762,12 @@ class Template
     }
 
     /**
-     * 搜索模板页面中包含的TagLib库
-     * 并返回列表
+     * 搜索模板页面中包含的 TagLib 库，并返回列表
      * @access private
      * @param  string $content 模板内容
-     * @return array|null
+     * @return array
      */
-    private function getIncludeTagLib(string &$content)
+    private function getIncludeTagLib(string &$content): array
     {
         // 搜索是否有TagLib标签
         if (preg_match($this->getRegex('taglib'), $content, $matches)) {
@@ -777,6 +776,8 @@ class Template
 
             return explode(',', $matches['name']);
         }
+
+        return [];
     }
 
     /**
@@ -805,8 +806,8 @@ class Template
     /**
      * 分析标签属性
      * @access public
-     * @param  string   $str 属性字符串
-     * @param  string   $name 不为空时返回指定的属性名
+     * @param string      $str  属性字符串
+     * @param string|null $name 不为空时返回指定的属性名
      * @return array
      */
     public function parseAttr(string $str, string $name = null): array

--- a/src/Template.php
+++ b/src/Template.php
@@ -878,7 +878,6 @@ class Template
                                 }
                             } else {
                                 if (isset($array[1])) {
-                                    $express = true;
                                     $this->parseVar($array[2]);
                                     $express = $name . $array[1] . $array[2];
                                 } else {
@@ -1169,24 +1168,13 @@ class Template
         $type  = strtoupper(trim(array_shift($vars)));
         $param = implode('.', $vars);
 
-        switch ($type) {
-            case 'CONST':
-                $parseStr = strtoupper($param);
-                break;
-            case 'NOW':
-                $parseStr = "date('Y-m-d g:i a',time())";
-                break;
-            case 'LDELIM':
-                $parseStr = '\'' . ltrim($this->config['tpl_begin'], '\\') . '\'';
-                break;
-            case 'RDELIM':
-                $parseStr = '\'' . ltrim($this->config['tpl_end'], '\\') . '\'';
-                break;
-            default:
-                $parseStr = defined($type) ? $type : '\'\'';
-        }
-
-        return $parseStr;
+        return match ($type) {
+            'CONST'  => strtoupper($param),
+            'NOW'    => "date('Y-m-d g:i a',time())",
+            'LDELIM' => '\'' . ltrim($this->config['tpl_begin'], '\\') . '\'',
+            'RDELIM' => '\'' . ltrim($this->config['tpl_end'], '\\') . '\'',
+            default  => defined($type) ? $type : '\'\'',
+        };
     }
 
     /**
@@ -1271,7 +1259,7 @@ class Template
         } else {
             $begin  = $this->config['taglib_begin'];
             $end    = $this->config['taglib_end'];
-            $single = strlen(ltrim($begin, '\\')) == 1 && strlen(ltrim($end, '\\')) == 1 ? true : false;
+            $single = strlen(ltrim($begin, '\\')) == 1 && strlen(ltrim($end, '\\')) == 1;
 
             switch ($tagName) {
                 case 'block':

--- a/src/Template.php
+++ b/src/Template.php
@@ -89,9 +89,9 @@ class Template
 
     /**
      * 查询缓存对象
-     * @var CacheInterface
+     * @var CacheInterface|null
      */
-    protected CacheInterface $cache;
+    protected ?CacheInterface $cache;
 
     /**
      * 架构函数
@@ -225,12 +225,10 @@ class Template
             $this->data = array_merge($this->data, $vars);
         }
 
-        if (!empty($this->config['cache_id']) && $this->config['display_cache'] && $this->cache) {
+        if ($this->isCache($this->config['cache_id'])) {
             // 读取渲染缓存
-            if ($this->cache->has($this->config['cache_id'])) {
-                echo $this->cache->get($this->config['cache_id']);
-                return;
-            }
+            echo $this->cache->get($this->config['cache_id']);
+            return;
         }
 
         $template = $this->parseTemplateFile($template);
@@ -254,7 +252,7 @@ class Template
             // 获取并清空缓存
             $content = ob_get_clean();
 
-            if (!empty($this->config['cache_id']) && $this->config['display_cache'] && $this->cache) {
+            if (!empty($this->config['cache_id']) && $this->config['display_cache'] && null !== $this->cache) {
                 // 缓存页面输出
                 $this->cache->set($this->config['cache_id'], $content, $this->config['cache_time']);
             }
@@ -271,7 +269,7 @@ class Template
      */
     public function isCache(string $cacheId): bool
     {
-        if ($cacheId && $this->cache && $this->config['display_cache']) {
+        if ($cacheId && null !== $this->cache && $this->config['display_cache']) {
             // 缓存页面输出
             return $this->cache->has($cacheId);
         }

--- a/src/Template.php
+++ b/src/Template.php
@@ -112,7 +112,7 @@ class Template
 
         // 初始化模板编译存储器
         $type  = $this->config['compile_type'] ? $this->config['compile_type'] : 'File';
-        $class = false !== strpos($type, '\\') ? $type : '\\think\\template\\driver\\' . ucwords($type);
+        $class = str_contains($type, '\\') ? $type : '\\think\\template\\driver\\' . ucwords($type);
 
         $this->storage = new $class();
     }
@@ -386,7 +386,7 @@ class Template
     {
         // 判断是否启用布局
         if ($this->config['layout_on']) {
-            if (false !== strpos($content, '{__NOLAYOUT__}')) {
+            if (str_contains($content, '{__NOLAYOUT__}')) {
                 // 可以单独定义不使用布局
                 $content = str_replace('{__NOLAYOUT__}', '', $content);
             } else {
@@ -567,7 +567,7 @@ class Template
 
                     foreach ($array as $k => $v) {
                         // 以$开头字符串转换成模板变量
-                        if (0 === strpos($v, '$')) {
+                        if (str_starts_with($v, '$')) {
                             $v = $this->get(substr($v, 1));
                         }
 
@@ -790,7 +790,7 @@ class Template
      */
     public function parseTagLib(string $tagLib, string &$content, bool $hide = false): void
     {
-        if (false !== strpos($tagLib, '\\')) {
+        if (str_contains($tagLib, '\\')) {
             // 支持指定标签库的命名空间
             $className = $tagLib;
             $tagLib    = substr($tagLib, strrpos($tagLib, '\\') + 1);
@@ -889,7 +889,7 @@ class Template
 
                                 if (in_array($first, ['?', '=', ':'])) {
                                     $str = trim(substr($str, 1));
-                                    if ('$' == substr($str, 0, 1)) {
+                                    if (str_starts_with($str, '$')) {
                                         $str = $this->parseVarFunction($str);
                                     }
                                 }
@@ -913,8 +913,8 @@ class Template
                                             // {$varname ? 'a' : 'b'} $varname为真时输出a,否则输出b
                                             $array = explode(':', $str, 2);
 
-                                            $array[0] = '$' == substr(trim($array[0]), 0, 1) ? $this->parseVarFunction($array[0]) : $array[0];
-                                            $array[1] = '$' == substr(trim($array[1]), 0, 1) ? $this->parseVarFunction($array[1]) : $array[1];
+                                            $array[0] = str_starts_with(trim($array[0]), '$') ? $this->parseVarFunction($array[0]) : $array[0];
+                                            $array[1] = str_starts_with(trim($array[1]), '$') ? $this->parseVarFunction($array[1]) : $array[1];
 
                                             $str = implode(' : ', $array);
                                         }
@@ -948,7 +948,7 @@ class Template
                     case '/':
                         // 注释标签
                         $flag2 = substr($str, 1, 1);
-                        if ('/' == $flag2 || ('*' == $flag2 && substr(rtrim($str), -2) == '*/')) {
+                        if ('/' == $flag2 || ('*' == $flag2 && str_ends_with(rtrim($str), '*/'))) {
                             $str = '';
                         }
                         break;
@@ -1034,7 +1034,7 @@ class Template
      */
     public function parseVarFunction(string &$varStr, bool $autoescape = true): string
     {
-        if (!$autoescape && false === strpos($varStr, '|')) {
+        if (!$autoescape && !str_contains($varStr, '|')) {
             return $varStr;
         } elseif ($autoescape && !preg_match('/\|(\s)?raw(\||\s)?/i', $varStr)) {
             $varStr .= '|' . $this->config['default_filter'];
@@ -1090,7 +1090,7 @@ class Template
                         $name = 'sprintf(' . $args[1] . ',' . $name . ')';
                         break;
                     case 'default': // 特殊模板函数
-                        if (false === strpos($name, '(')) {
+                        if (!str_contains($name, '(')) {
                             $name = '(isset(' . $name . ') && (' . $name . ' !== \'\')?' . $name . ':' . $args[1] . ')';
                         } else {
                             $name = '(' . $name . ' ?: ' . $args[1] . ')';
@@ -1098,7 +1098,7 @@ class Template
                         break;
                     default: // 通用模板函数
                         if (isset($args[1])) {
-                            if (strstr($args[1], '###')) {
+                            if (str_contains($args[1], '###')) {
                                 $args[1] = str_replace('###', $name, $args[1]);
                                 $name    = "$fun($args[1])";
                             } else {
@@ -1207,7 +1207,7 @@ class Template
                 continue;
             }
 
-            if (0 === strpos($templateName, '$')) {
+            if (str_starts_with($templateName, '$')) {
                 //支持加载变量文件名
                 $templateName = $this->get(substr($templateName, 1));
             }
@@ -1233,7 +1233,7 @@ class Template
     {
         if ('' == pathinfo($template, PATHINFO_EXTENSION)) {
 
-            if (0 !== strpos($template, '/')) {
+            if (!str_starts_with($template, '/')) {
                 $template = str_replace(['/', ':'], $this->config['view_depr'], $template);
             } else {
                 $template = str_replace(['/', ':'], $this->config['view_depr'], substr($template, 1));

--- a/src/Template.php
+++ b/src/Template.php
@@ -245,11 +245,7 @@ class Template
 
             // 页面缓存
             ob_start();
-            if (PHP_VERSION > 8.0) {
-                ob_implicit_flush(false);
-            } else {
-                ob_implicit_flush(0);
-            }
+            ob_implicit_flush(false);
 
             // 读取编译存储
             $this->storage->read($cacheFile, $this->data);

--- a/src/template/contract/DriverInterface.php
+++ b/src/template/contract/DriverInterface.php
@@ -1,0 +1,35 @@
+<?php
+namespace think\template\contract;
+
+/**
+ * 模板编译存储器驱动接口
+ */
+interface DriverInterface
+{
+    /**
+     * 写入编译缓存
+     * @access public
+     * @param  string $cacheFile 缓存的文件名
+     * @param  string $content 缓存的内容
+     * @return void
+     */
+    public function write(string $cacheFile, string $content): void;
+
+    /**
+     * 读取编译编译
+     * @access public
+     * @param  string  $cacheFile 缓存的文件名
+     * @param  array   $vars 变量数组
+     * @return void
+     */
+    public function read(string $cacheFile, array $vars = []): void;
+
+    /**
+     * 检查编译缓存是否有效
+     * @access public
+     * @param  string  $cacheFile 缓存的文件名
+     * @param  int     $cacheTime 缓存时间
+     * @return bool
+     */
+    public function check(string $cacheFile, int $cacheTime): bool;
+}

--- a/src/template/driver/File.php
+++ b/src/template/driver/File.php
@@ -12,8 +12,9 @@
 namespace think\template\driver;
 
 use Exception;
+use think\template\contract\DriverInterface;
 
-class File
+class File implements DriverInterface
 {
     protected $cacheFile;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/tag/Demo.php';

--- a/tests/tag/Demo.php
+++ b/tests/tag/Demo.php
@@ -1,0 +1,46 @@
+<?php
+namespace tag;
+
+use think\template\TagLib;
+class Demo extends TagLib{
+    /**
+     * 定义标签列表
+     */
+    protected $tags   =  [
+        // 标签定义： attr 属性列表 close 是否闭合（0 或者1 默认1） alias 标签别名 level 嵌套层次
+        'close'     => ['attr' => 'time,format', 'close' => 0], //闭合标签，默认为不闭合
+        'open'      => ['attr' => 'name,type', 'close' => 1],
+
+    ];
+
+    /**
+     * 这是一个闭合标签的简单演示
+     */
+    public function tagClose($tag)
+    {
+        $format = empty($tag['format']) ? 'Y-m-d H:i:s' : $tag['format'];
+        $time = empty($tag['time']) ? time() : $tag['time'];
+        $parse = '<?php ';
+        $parse .= 'echo date("' . $format . '",' . $time . ');';
+        $parse .= ' ?>';
+        return $parse;
+    }
+
+    /**
+     * 这是一个非闭合标签的简单演示
+     */
+    public function tagOpen($tag, $content)
+    {
+        $type = empty($tag['type']) ? 0 : 1; // 这个type目的是为了区分类型，一般来源是数据库
+        $name = $tag['name']; // name是必填项，这里不做判断了
+        $parse = '<?php ';
+        $parse .= '$test_arr=[[1,3,5,7,9],[2,4,6,8,10]];'; // 这里是模拟数据
+        $parse .= '$__LIST__ = $test_arr[' . $type . '];';
+        $parse .= ' ?>';
+        $parse .= '{volist name="__LIST__" id="' . $name . '"}';
+        $parse .= $content;
+        $parse .= '{/volist}';
+        return $parse;
+    }
+
+}

--- a/tests/template/extend.html
+++ b/tests/template/extend.html
@@ -1,0 +1,2 @@
+{block name="title"}标题{/block}
+{block name="main"}主内容{/block}

--- a/tests/template/fetch.html
+++ b/tests/template/fetch.html
@@ -1,0 +1,1 @@
+success

--- a/tests/template/include.html
+++ b/tests/template/include.html
@@ -1,0 +1,1 @@
+include

--- a/tests/template/layout.html
+++ b/tests/template/layout.html
@@ -1,0 +1,1 @@
+start{__CONTENT__}end

--- a/tests/think/TemplateTest.php
+++ b/tests/think/TemplateTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace think;
+
+use PHPUnit\Framework\TestCase;
+use tag\Demo;
+
+class TemplateTest extends TestCase
+{
+    public function getTemplate()
+    {
+        $config = [
+            'view_path'          => __DIR__ . '/../template' . DIRECTORY_SEPARATOR,
+            'cache_path'         => __DIR__ . '/../cache' . DIRECTORY_SEPARATOR,
+            'tpl_cache'          => false,
+            'tpl_replace_string' => ['__STATIC__' => '/static'],
+            'taglib_pre_load'    => Demo::class,
+        ];
+        return new Template($config);
+    }
+
+    // 直接渲染
+    public function testDisplay()
+    {
+        $this->expectOutputString('hello-thinkphp');
+
+        $template = $this->getTemplate();
+        $content = '{$name}-{$email}';
+        $template->display($content, ['name' => 'hello', 'email' => 'thinkphp']);
+    }
+
+    // 渲染文件
+    public function testFetch()
+    {
+        $this->expectOutputString('success');
+
+        $template = $this->getTemplate();
+        $template->fetch('fetch');
+    }
+
+    // 布局
+    public function testLayout()
+    {
+        $this->expectOutputString('startsuccessend');
+
+        $template = $this->getTemplate();
+        $template->layout('layout');
+        $template->fetch('fetch');
+        $template->layout(false);
+    }
+
+    // 扩展解析
+    public function testExtend()
+    {
+        $this->expectOutputString('test.name');
+
+        $template = $this->getTemplate();
+        $template->extend('$Cms', function (array $vars) {
+            return '\'' . implode('.', $vars) . '\'';
+        });
+
+        $content = '{$Cms.test.name}';
+        $template->display($content);
+    }
+
+    // 变量
+    public function testParseVar()
+    {
+        $this->expectOutputString('e10adc3949ba59abbe56e057f20f883e');
+
+        $template = $this->getTemplate();
+        $content = '{:md5("123456")}';
+        $template->display($content, ['password' => '123456']);
+    }
+
+    // 变量使用函数
+    public function testParseVarFunction()
+    {
+        $this->expectOutputString('e10adc3949ba59abbe56e057f20f883e-123456-666456');
+
+        $template = $this->getTemplate();
+        $content = '{$password|md5}-{$password|raw}-{$password|str_replace=123,666,###}';
+        $template->display($content, ['password' => '123456']);
+    }
+
+    // 默认值
+    public function testParseDefaultFunction()
+    {
+        $this->expectOutputString('test');
+
+        $template = $this->getTemplate();
+        $content = '{$default|default="test"}';
+        $template->display($content);
+    }
+
+    // 系统变量
+    public function testParseThinkVar()
+    {
+        $this->expectOutputString($_SERVER['PHP_SELF'] . '-' . PHP_VERSION . '-' . PHP_VERSION);
+
+        $template = $this->getTemplate();
+        $content = '{$Request.server.PHP_SELF}-{$Think.const.PHP_VERSION}-{$Think.PHP_VERSION}';
+        $template->display($content);
+    }
+
+    // 数组
+    public function testParseArrayVar()
+    {
+        $this->expectOutputString('thinkphp<br/>thinkphp');
+
+        $template = $this->getTemplate();
+        $content = '{$data.name}<br/>{$data["name"]}';
+        $template->display($content, ['data' => ['name' => 'thinkphp']]);
+    }
+
+    // 对象
+    public function testParseObjectVar()
+    {
+        $this->expectOutputString('a-b-c-d');
+
+        $object = new class {
+            public string $a = 'a';
+            public const b = 'b';
+
+            public function c($str) {
+                return $str;
+            }
+
+            static public function d($str) {
+                return $str;
+            }
+        };
+
+        $template = $this->getTemplate();
+        $content = '{$data->a}-{$data::b}-{$data->c("c")}-{$data::d("d")}';
+        $template->display($content, ['data' => $object]);
+    }
+
+    // 运算符
+    public function testParseVarOperator()
+    {
+        $this->expectOutputString('2-0-2-0.5-1-1-1-4');
+
+        $template = $this->getTemplate();
+        $content = '{$a+1}-{$a-1}-{$a*$b}-{$a/$b}-{$a%$b}-{$a++}-{--$b}-{$a+$b+abs(-1)}';
+        $template->display($content, ['a' => 1, 'b' => 2]);
+    }
+
+    // 三元运算符
+    public function testParseTernaryOperator()
+    {
+        $this->expectOutputString('真-默认值-有值-NO');
+
+        $template = $this->getTemplate();
+        $content = '{$true?"真":"假"}-{$null ?? "默认值"}-{$one ?= "有值"}-{$zero ?: "NO"}';
+        $template->display($content, ['null' => null, 'zero' => 0, 'true' => true, 'one' => 1]);
+    }
+
+    // 单行注释
+    public function testParseSimpleNote()
+    {
+        $this->expectOutputString('123');
+
+        $template = $this->getTemplate();
+        $content = '123{// 注释内容 }';
+        $template->display($content);
+    }
+
+    // 多行注释
+    public function testParseMoreNote()
+    {
+        $this->expectOutputString('123');
+
+        $template = $this->getTemplate();
+        $content = "123{/* 这是模板\r\n注释内容*/ }";
+        $template->display($content);
+    }
+
+    // 引用标签
+    public function testParseInclude()
+    {
+        $this->expectOutputString('include');
+
+        $template = $this->getTemplate();
+        $content = '{include file="include"}';
+        $template->display($content);
+    }
+
+    // 继承标签
+    public function testParseExtend()
+    {
+        $this->expectOutputString("title\r\n主内容main\r\n");
+
+        $template = $this->getTemplate();
+        $content = "{extend name='extend' /}\r\n{block name='title'}title{/block}\r\n{block name='main'}{__block__}main{/block}";
+        $template->display($content);
+    }
+
+    // 输出替换
+    public function testParseReplaceString()
+    {
+        $this->expectOutputString("start/staticend");
+
+        $template = $this->getTemplate();
+        $content = "start__STATIC__end";
+        $template->display($content);
+    }
+
+    // 标签扩展
+    public function testParseDemoTag()
+    {
+        $this->expectOutputString(<<<'HTML'
+<h1>闭合标签</h1>
+2022-12-31 16:00:00<hr>
+<h1>开放标签</h1>
+    0=>1<br>
+    1=>3<br>
+    2=>5<br>
+    3=>7<br>
+    4=>9<br>
+<br>
+    0=>2<br>
+    1=>4<br>
+    2=>6<br>
+    3=>8<br>
+    4=>10<br>
+
+HTML);
+
+        $template = $this->getTemplate();
+        $content = <<<'HTML'
+<h1>闭合标签</h1>
+{demo:close time='$demo_time'/}
+<hr>
+<h1>开放标签</h1>
+{demo:open name='demo_name'}
+    {$key}=>{$demo_name}<br>
+{/demo:open}
+<br>
+{demo:open name='demo_name' type='1'}
+    {$key}=>{$demo_name}<br>
+{/demo:open}
+HTML;
+
+        $template->display($content, ['demo_time' => 1672502400]);
+    }
+}


### PR DESCRIPTION
* 升级版本依赖，对齐 thinkphp 8.0 -dev（php:>=8.0.0、psr/simple-cache:^3.0）
* 删除 PHP 版本是否大于 8.0 的判断
* 增加模板编译存储器驱动接口类`think\template\contract\DriverInterface`
* 删除正则表达式中冗余字符转义 `\.`
* 添加属性类型、返回类型和参数类型
* 使用 `str_contains`、`str_starts_with`、`str_ends_with`
* 简化缓存调用代码
* 简化 switch 为 match
* 清理冗余代码 `a == b ? true : false` => `a == b`
* 添加单元测试