### PR TITLE
修复php 8及以上强类型htmlentities函数导致异常问题

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -1068,6 +1068,9 @@ class Template
                 switch (strtolower($fun)) {
                     case 'raw':
                         break;
+                    case 'htmlentities':
+                        $name = 'htmlentities((string) ' . $name . ')';
+                        break;
                     case 'date':
                         $name = 'date(' . $args[1] . ',!is_numeric(' . $name . ')? strtotime(' . $name . ') : ' . $name . ')';
                         break;


### PR DESCRIPTION
数据库输出数据到模版文件当内容为null的时候htmlentities第一参数就会报参数类型错误