### PR TITLE
修复当变量值为空时模板文件不存在的错误

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -1206,13 +1206,13 @@ class Template
         $parseStr = '';
 
         foreach ($array as $templateName) {
-            if (empty($templateName)) {
-                continue;
-            }
-
             if (0 === strpos($templateName, '$')) {
                 //支持加载变量文件名
                 $templateName = $this->get(substr($templateName, 1));
+            }
+            
+            if (empty($templateName)) {
+                continue;
             }
 
             $template = $this->parseTemplateFile($templateName);


### PR DESCRIPTION
当变量值为空时会抛出模板文件不存在的异常，模板名为空的判断位置不能太靠前了，需要在获取变量值之后再进行判断