### PR TITLE
在cli常驻模式下，编译文件写入后清除`opcache`状态

### DIFF
--- a/src/template/driver/File.php
+++ b/src/template/driver/File.php
@@ -39,7 +39,7 @@ class File implements DriverInterface
             throw new Exception('cache write error:' . $cacheFile, 11602);
         }
 
-        if(php_sapi_name() === 'cli' && function_exists('opcache_invalidate')) {
+        if (php_sapi_name() === 'cli' && function_exists('opcache_invalidate')) {
             opcache_invalidate($cacheFile, true);
         }
     }

--- a/src/template/driver/File.php
+++ b/src/template/driver/File.php
@@ -38,6 +38,10 @@ class File implements DriverInterface
         if (false === file_put_contents($cacheFile, $content)) {
             throw new Exception('cache write error:' . $cacheFile, 11602);
         }
+
+        if(php_sapi_name() === 'cli' && function_exists('opcache_invalidate')) {
+            opcache_invalidate($cacheFile, true);
+        }
     }
 
     /**


### PR DESCRIPTION
Invalidate OPcache for the cache file when running in CLI mode.